### PR TITLE
Potential fix for code scanning alert no. 1: Inefficient regular expression

### DIFF
--- a/src/mermaidClassDiagramParser.ts
+++ b/src/mermaidClassDiagramParser.ts
@@ -225,7 +225,7 @@ export class MermaidClassDiagramParser {
 
                 const matchMethod = trimmedMember.match(/([+\-#~])\s*(\w+)\s*\(([^)]*)\)\s*:\s*([\w~<>,\s]+)/);
                 const matchAttribute = trimmedMember.match(
-                    /([+\-#~])\s*([\w<>~,\[\]\s\.\?]+)\s+(\w+)\s*(?:=\s*([^;]*))?;*([\*\$]*)*?$/,
+                    /([+\-#~])\s*([\w<>~,\[\]\s\.\?]+)\s+(\w+)\s*(?:=\s*([^;]*))?;*([\*\$]*)$/,
                 );
                 const matchType = trimmedMember.match(/<<(.*?)>>/);
                 const matchOption = trimmedMember.match(/^(\w+)(?:\s*=\s*(\w+))?$/);


### PR DESCRIPTION
Potential fix for [https://github.com/ReneLombard/mermaid-codegen/security/code-scanning/1](https://github.com/ReneLombard/mermaid-codegen/security/code-scanning/1)

In general, to fix inefficient regular expressions that can cause exponential backtracking, you eliminate ambiguous nested quantifiers such as `(r*)*`, `(r+)+`, or `(...)*?` where the inner part can match the same text in multiple ways. The usual remedy is to collapse nested repetitions into a single repetition, or to refactor alternatives so that they are mutually exclusive.

In this case, the attribute regex is:

```ts
const matchAttribute = trimmedMember.match(
    /([+\-#~])\s*([\w<>~,\[\]\s\.\?]+)\s+(\w+)\s*(?:=\s*([^;]*))?;*([\*\$]*)*?$/,
);
```

The final portion `([\*\$]*)*?$` is the problematic part. The intention appears to be: “zero or more classifier characters `*` or `$` at the end of the line”, captured as group 5. That can be expressed unambiguously as a *single* quantified character class, `([\*\$]*)$`, which allows any length of `*`/`$` sequence and keeps exactly the same capture group content as the original (the innermost `[\*\$]*`), while removing the outer redundant `*?`. So the best fix is to replace `;*([\*\$]*)*?$` with `;*([\*\$]*)$`. This keeps all capture groups and their indices the same and does not change any other behavior of the pattern.

Only one change is needed: in `src/mermaidClassDiagramParser.ts`, inside `addMembers`, on the line defining `matchAttribute`, adjust the regex literal accordingly. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
